### PR TITLE
jaydebeapi 1.x.x compatibility fix

### DIFF
--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -280,8 +280,11 @@ class IdaDataBase(object):
                     if verbose: print("Found it at %s! Trying to connect..."%jarpath)
                        
                 jpype.startJVM(jpype.getDefaultJVMPath(), '-Djava.class.path=%s' % jarpath)
-           
-            self._connection_string = [jdbc_url, uid, pwd]
+
+            if jaydebeapi.__version__.startswith('0'):
+                self._connection_string = [jdbc_url, uid, pwd]
+            else:
+                self._connection_string = jdbc_url + ':user={};password={};'.format(uid, pwd)
             
             driver_not_found = ("HELP: The JDBC driver for IBM dashDB/DB2 could "+
             "not be found. Please download the latest JDBC Driver at the "+

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='ibmdbpy',
       install_requires=['pandas','numpy','future','six','pypyodbc','lazy'],
       # optional are jaydebeapi, pytest, sphinx, bokeh
       extras_require={
-        'jdbc':['jaydebeapi>=0.2.0,<1.0.0'],
+        'jdbc':['jaydebeapi'],
         'test':['pytest', 'flaky==3.4.0'],
         'doc':['sphinx']
       },


### PR DESCRIPTION
As of 1.x.x, `jaydebeapi.connect` changed the format of its connection string arguments from a list to a string (https://stackoverflow.com/a/25567933/1714512). This broke the call in IdaDataBase initialization (https://github.com/ibmdbanalytics/ibmdbpy/issues/18). This small fix checks the version of jaydebeapi and chooses the appropriate form for the arguments of `jaydebeapi.connect`.