### PR TITLE
_get_index: Return a RangeIndex

### DIFF
--- a/ibmdbpy/frame.py
+++ b/ibmdbpy/frame.py
@@ -42,7 +42,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-from pandas.core.index import Index
+from pandas.core.index import Index, RangeIndex
 
 from lazy import lazy
 import six
@@ -2093,17 +2093,7 @@ class IdaDataFrame(object):
 
         rows = self.shape[0]
 
-        # Prevent user from loading an index that is too big
-        if not force:
-            threshold = 10000
-            if rows > threshold:
-                print("WARNING : the index has %s elements." %self.shape[0])
-                question = "Do you want to download it in memory ?"
-                display_yes = ibmdbpy.utils.query_yes_no(question)
-                if not display_yes:
-                    return None
-
-        return Index(np.arange(0, rows))
+        return RangeIndex(0, rows, 1)
 
     def _get_shape(self):
         """

--- a/ibmdbpy/tests/test_frame.py
+++ b/ibmdbpy/tests/test_frame.py
@@ -62,7 +62,7 @@ class Test_OpenDataFrameObject(object):
 
     def test_idadf_attr_index(self, idadf, df):
         # Ok, but what do we do if too big ?
-        assert type(idadf.index) in [pandas.core.index.Int64Index,pandas.core.index.Index] # Not sure here
+        assert type(idadf.index) in [pandas.Int64Index, pandas.Index, pandas.RangeIndex]  # Not sure here
         assert list(idadf.index) == list(df.index)
 
     def test_idadf_attr_columns(self, idadf, df):


### PR DESCRIPTION
A RangeIndex uses a constant amount of memory, so we don't need to prompt the
user if they really want to create the index anymore.

Test results are at https://ibm.co/2KX1hqZ.