### PR TITLE
Return type corrected in new testcases for issue 20

### DIFF
--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -53,8 +53,8 @@ def _numeric_stats(idadf, stat, columns):
 
     Returns
     -------
-    Tuple
-        One value for each column.
+    Tuple or float64
+        One value for each column. For a one column input a float64 value is returned except for median
 
     Notes
     -----

--- a/ibmdbpy/tests/test_statistics.py
+++ b/ibmdbpy/tests/test_statistics.py
@@ -45,13 +45,13 @@ class Test_PrivateStatisticsMethods(object):
         data = idadf._table_def() # We necessarly have to put the test under this condition
         allcolumns = list(data.loc[data['VALTYPE'] == "NUMERIC"].index)
         columns = [allcolumns[0]]
-        assert isinstance(_numeric_stats(idadf, "count", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "mean", columns), numpy.ndarray)
+        assert isinstance(_numeric_stats(idadf, "count", columns), numpy.float64)
+        assert isinstance(_numeric_stats(idadf, "mean", columns), numpy.float64)
         assert isinstance(_numeric_stats(idadf, "median", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "std", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "var", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "min", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "max", columns), numpy.ndarray)
+        assert isinstance(_numeric_stats(idadf, "std", columns), numpy.float64)
+        assert isinstance(_numeric_stats(idadf, "var", columns), numpy.float64)
+        assert isinstance(_numeric_stats(idadf, "min", columns), numpy.float64)
+        assert isinstance(_numeric_stats(idadf, "max", columns), numpy.float64)
 
     def test_idadf_numeric_stats_accuracy(self, idadf):
         pass


### PR DESCRIPTION
The return types of the new test case test_idadf_numeric_stats_one_column have been corrected. 
All test cases in test_statistics.py succeed with the fix of issue 20:

> test_statistics.py ...................................                   [ 98%]

Without the fix, test_idadf_numeric_stats_one_column fails :

```
test_statistics.py .F.................................                   [ 98%]

______ Test_PrivateStatisticsMethods.test_idadf_numeric_stats_one_column _______

self = <test_statistics.Test_PrivateStatisticsMethods object at 0x2ae9e205f650>
idadf = <ibmdbpy.frame.IdaDataFrame object at 0x2ae9a5ca3e10>

    def test_idadf_numeric_stats_one_column(self, idadf):
        data = idadf._table_def() # We necessarly have to put the test under this condition
        allcolumns = list(data.loc[data['VALTYPE'] == "NUMERIC"].index)
        columns = [allcolumns[0]]
        assert isinstance(_numeric_stats(idadf, "count", columns), numpy.float64)
        assert isinstance(_numeric_stats(idadf, "mean", columns), numpy.float64)
        assert isinstance(_numeric_stats(idadf, "median", columns), numpy.ndarray)
>       assert isinstance(_numeric_stats(idadf, "std", columns), numpy.float64)
```