### PR TITLE
Mark known failures as such

### DIFF
--- a/ibmdbpy/tests/conftest.py
+++ b/ibmdbpy/tests/conftest.py
@@ -192,6 +192,20 @@ def idadf(request, idadb):
     return idadf
 
 @pytest.fixture(scope="session")
+def idadf_onecolumn_numeric(idadf):
+    """
+
+    IdaDataFrame fixture with a single numeric column to be used for the whole
+    testing session.
+    Shall not be used during the testing procedure by destructive and
+    semi-destructive functions.
+    """
+    table_def = idadf._table_def()
+    numeric_column = table_def[table_def["VALTYPE"] == "NUMERIC"].index.tolist()[:1]
+    single_column_dataframe = idadf[numeric_column]
+    return single_column_dataframe
+
+@pytest.fixture(scope="session")
 def idadf_indexer(request, idadb, idadf):
     """
     IdaDataFrame fixture with indexer defined to be used for the whole testing session.

--- a/ibmdbpy/tests/conftest.py
+++ b/ibmdbpy/tests/conftest.py
@@ -235,7 +235,7 @@ def idadf_tmp(request, idadb):
     idadf = idadb.as_idadataframe(data, 'TEST_IBMDBPY_TMP', clear_existing = True)
     idadb.commit()
     return idadf
-    
+
 @pytest.fixture(scope="function")
 def idageodf_county(idadb):
     """
@@ -256,8 +256,8 @@ def idageodf_customer(idadb):
     Don't use it for destructive nor non-destructive methods (modify columns)
     """
     idageodf = ibmdbpy.IdaGeoDataFrame(idadb, 'SAMPLES.GEO_CUSTOMER', indexer='OBJECTID')
-    return idageodf    
-    
+    return idageodf
+
 @pytest.fixture(scope="function")
 def idageodf_tornado(idadb):
     """
@@ -346,4 +346,3 @@ def session_teardown(idadb, idadf, idaview, request):
 #    if 'table' in metafunc.fixturenames:
 #        metafunc.parametrize("table",
 #                             metafunc.config.option.table, scope = 'session')
-

--- a/ibmdbpy/tests/test_statistics.py
+++ b/ibmdbpy/tests/test_statistics.py
@@ -42,17 +42,15 @@ class Test_PrivateStatisticsMethods(object):
         assert isinstance(_numeric_stats(idadf, "min", columns), numpy.ndarray)
         assert isinstance(_numeric_stats(idadf, "max", columns), numpy.ndarray)
 
-    def test_idadf_numeric_stats_one_column(self, idadf):
-        data = idadf._table_def() # We necessarly have to put the test under this condition
-        allcolumns = list(data.loc[data['VALTYPE'] == "NUMERIC"].index)
-        columns = [allcolumns[0]]
-        assert isinstance(_numeric_stats(idadf, "count", columns), numpy.float64)
-        assert isinstance(_numeric_stats(idadf, "mean", columns), numpy.float64)
-        assert isinstance(_numeric_stats(idadf, "median", columns), numpy.ndarray)
-        assert isinstance(_numeric_stats(idadf, "std", columns), numpy.float64)
-        assert isinstance(_numeric_stats(idadf, "var", columns), numpy.float64)
-        assert isinstance(_numeric_stats(idadf, "min", columns), numpy.float64)
-        assert isinstance(_numeric_stats(idadf, "max", columns), numpy.float64)
+    def test_idadf_onecolumn_numeric_numeric_stats_one_column(self, idadf_onecolumn_numeric):
+        column = idadf_onecolumn_numeric.columns.tolist()
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "count", column), numpy.float64)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "mean", column), numpy.float64)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "median", column), numpy.ndarray)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "std", column), numpy.float64)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "var", column), numpy.float64)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "min", column), numpy.float64)
+        assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "max", column), numpy.float64)
 
     @pytest.mark.parametrize("f",
                              [IDADF.describe,
@@ -70,12 +68,8 @@ class Test_PrivateStatisticsMethods(object):
                               IDADF.sum,
                               IDADF.median,
                              ])
-    def test_idadf_statistics_one_column(self, idadf, f):
-        table_def = idadf._table_def()
-        numeric_column = table_def[table_def["VALTYPE"] == "NUMERIC"].index.tolist()[:1]
-        single_column_dataframe = idadf[numeric_column]
-        f(single_column_dataframe)
-
+    def test_idadf_statistics_one_column(self, idadf_onecolumn_numeric, f):
+        f(idadf_onecolumn_numeric)
 
     def test_idadf_numeric_stats_accuracy(self, idadf):
         pass

--- a/ibmdbpy/tests/test_statistics.py
+++ b/ibmdbpy/tests/test_statistics.py
@@ -52,25 +52,6 @@ class Test_PrivateStatisticsMethods(object):
         assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "min", column), numpy.float64)
         assert isinstance(_numeric_stats(idadf_onecolumn_numeric, "max", column), numpy.float64)
 
-    @pytest.mark.parametrize("f",
-                             [IDADF.describe,
-                              IDADF.cov,
-                              IDADF.corr,
-                              IDADF.quantile,
-                              IDADF.mad,
-                              IDADF.min,
-                              IDADF.max,
-                              IDADF.count,
-                              IDADF.count_distinct,
-                              IDADF.std,
-                              IDADF.var,
-                              IDADF.mean,
-                              IDADF.sum,
-                              IDADF.median,
-                             ])
-    def test_idadf_statistics_one_column(self, idadf_onecolumn_numeric, f):
-        f(idadf_onecolumn_numeric)
-
     def test_idadf_numeric_stats_accuracy(self, idadf):
         pass
 
@@ -203,3 +184,22 @@ class Test_DescriptiveStatistics(object):
 
     def test_idadf_median(self, idadf, df):
         assert str(idadf.median()) == str(df.median())
+
+    @pytest.mark.parametrize("f",
+                             [IDADF.describe,
+                              IDADF.cov,
+                              IDADF.corr,
+                              IDADF.quantile,
+                              IDADF.mad,
+                              IDADF.min,
+                              IDADF.max,
+                              IDADF.count,
+                              IDADF.count_distinct,
+                              IDADF.std,
+                              IDADF.var,
+                              IDADF.mean,
+                              IDADF.sum,
+                              IDADF.median,
+                             ])
+    def test_idadf_statistics_one_column(self, idadf_onecolumn_numeric, f):
+        f(idadf_onecolumn_numeric)

--- a/ibmdbpy/tests/test_statistics.py
+++ b/ibmdbpy/tests/test_statistics.py
@@ -187,10 +187,10 @@ class Test_DescriptiveStatistics(object):
 
     @pytest.mark.parametrize("f",
                              [IDADF.describe,
-                              IDADF.cov,
-                              IDADF.corr,
+                              pytest.param(IDADF.cov, marks=pytest.mark.xfail),
+                              pytest.param(IDADF.corr, marks=pytest.mark.xfail),
                               IDADF.quantile,
-                              IDADF.mad,
+                              pytest.param(IDADF.mad, marks=pytest.mark.xfail),
                               IDADF.min,
                               IDADF.max,
                               IDADF.count,

--- a/mv_to_docker/requirements_27_odbc.txt
+++ b/mv_to_docker/requirements_27_odbc.txt
@@ -3,6 +3,6 @@ lazy==1.2
 numpy==1.11.2
 pandas==0.19.2
 pypyodbc==1.3.3.1
-pytest==3.0.5
+pytest==3.7.0
 flaky==3.4.0
 six==1.10.0

--- a/mv_to_docker/requirements_35_odbc.txt
+++ b/mv_to_docker/requirements_35_odbc.txt
@@ -3,6 +3,6 @@ lazy==1.2
 numpy==1.11.2
 pandas==0.19.2
 pypyodbc==1.3.4.3
-pytest==3.0.5
+pytest==3.7.0
 flaky==3.4.0
 six==1.10.0

--- a/mv_to_docker/requirements_jdbc.txt
+++ b/mv_to_docker/requirements_jdbc.txt
@@ -3,6 +3,6 @@ JayDeBeApi==0.2.0
 lazy==1.2
 numpy==1.11.2
 pandas==0.19.2
-pytest==3.0.5
+pytest==3.7.0
 flaky==3.4.0
 six==1.10.0


### PR DESCRIPTION
`cov`, `corr` and `mad` don't work with single-column dataframes at the moment. Just mark their tests as expected to fail.

Also, provide an `idadf_onecolumn_numeric` test fixture to get rid of repetition.

Test results are at https://ibm.co/2M6riSf