### PR TITLE
Lock jpype to 0.6

### DIFF
--- a/mv_to_docker/requirements_jdbc.txt
+++ b/mv_to_docker/requirements_jdbc.txt
@@ -1,5 +1,6 @@
 future==0.16.0
 JayDeBeApi==0.2.0
+JPype1==0.6.3
 lazy==1.2
 numpy==1.11.2
 pandas==0.19.2

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='ibmdbpy',
       install_requires=['pandas','numpy','future','six','pypyodbc','lazy'],
       # optional are jaydebeapi, pytest, sphinx, bokeh
       extras_require={
-        'jdbc':['jaydebeapi'],
+        'jdbc':['jaydebeapi', 'JPype1==0.6.3'],
         'test':['pytest', 'flaky==3.4.0'],
         'doc':['sphinx']
       },


### PR DESCRIPTION
This is a workaround for https://github.com/ibmdbanalytics/ibmdbpy/issues/45
because ibmdbpy and jaydebeapi are not compatible with jpype 0.7 yet.

- https://bit.ly/2Xjz0SD