### PR TITLE
fix jdbc connection to properly support parameters like sslConnection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__
 *.pyo
 *.tmp*
 *.bak
+
+### VSCode
+*.code-workspace

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -188,12 +188,6 @@ class IdaDataBase(object):
 
         if self._con_type == 'jdbc':
 
-            # deprecate this and throw error, this is very old version at this point.
-            # now we can just focus on building a single parameter string.
-            if (jaydebeapi.__version__.startswith('0')):
-                message = ("You jaydebeapi module is deprecated.  Please install version 1.x or higher.")
-                raise IdaDataBaseError(message)    
-
             # remove trailing ":" or ";" or spaces on dsn, we will replace.
             dsn = dsn.rstrip(';: ')
             # find parameters on dsn; if any exist, there will be an equals sign.
@@ -296,6 +290,11 @@ class IdaDataBase(object):
                 jpype.startJVM(jpype.getDefaultJVMPath(), '-Djava.class.path=%s' % jarpath)
 
             if jaydebeapi.__version__.startswith('0'):
+                # deprecate this and throw error, this is very old version at this point.
+                # now we can just focus on building a single parameter string.
+                message = ("You jaydebeapi module is deprecated.  Please install version 1.x or higher.")
+                raise IdaDataBaseError(message)
+            
                 self._connection_string = [jdbc_url, uid, pwd]
             else:
                 #self._connection_string = jdbc_url + ':user={};password={};'.format(uid, pwd)


### PR DESCRIPTION
The existing code breaks when additional parameters are present in the JDBC connection string because it does not properly parse the string.
The fixed code simplifies the dsn string handling.  It is NOT backwards compatible with jaydebeapi versions 0.x and earlier.  However, this was several versions back - so it is reasonable to fail with an error specifying that the library should be updated to version 1.x or later.