### PR TITLE
Fix the documentation build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.pngmath',
+    'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'IPython.sphinxext.ipython_console_highlighting',

--- a/docs/source/geoFrame.rst
+++ b/docs/source/geoFrame.rst
@@ -30,7 +30,7 @@ Create from an IdaDataFrame
 
 Get the geometry attribute
 --------------------------
-.. automethod:: IdaGeoDataFrame.geometry
+.. autoattribute:: IdaGeoDataFrame.geometry
 
 Geospatial Methods that return an IdaGeoDataFrame
 =================================================
@@ -91,6 +91,3 @@ Union
 Within
 ------
 .. automethod:: IdaGeoDataFrame.within
-
-
-

--- a/docs/source/geoSeries.rst
+++ b/docs/source/geoSeries.rst
@@ -170,7 +170,7 @@ perimeter
 
 Start Point
 -----------
-..automethod:: IdageoSeries.start_point
+.. automethod:: IdaGeoSeries.start_point
 
 SR ID
 -----

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(name='ibmdbpy',
       extras_require={
         'jdbc':['jaydebeapi', 'JPype1==0.6.3'],
         'test':['pytest', 'flaky==3.4.0'],
-        'doc':['sphinx']
+        'doc':['sphinx', 'ipython', 'numpydoc', 'sphinx_rtd_theme']
       },
       description='A Pandas-like SQL-wrapper for in-database analytics with IBM Db2 Warehouse.',
       long_description=longdesc,


### PR DESCRIPTION
The individual commits have more details. Most importantly, all dependencies for running a build are now installed by the `docs` feature.


```
↪ virtualenv venv  
Using base prefix '/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7'
New python executable in /Users/wieland/dev/ibmdbpy/venv/bin/python3.7
Also creating executable in /Users/wieland/dev/ibmdbpy/venv/bin/python
Installing setuptools, pip, wheel...
venv/done.

↪ source venv/bin/activate 
(venv) ↪ pip install ".[doc]"
[... lots of output ...]
(venv) ↪ cd docs 
(venv) ↪ make html
[... lots of output, still full of warnings ...]
copying static files... ... erledigt
copying extra files... erledigt
dumping search index in English (code: en)... erledigt
dumping object inventory... erledigt
build abgeschlossen, 43 warnings.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```