### PR TITLE
Tb ibmdbpy changes

### DIFF
--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -585,7 +585,7 @@ class IdaDataBase(object):
         if len(tablelist):
              tabletype = tablelist['TYPE'].values[0]
              raise TypeError("%s.%s exists, but is not a model (of type '%s')"
-                  %(modelschema, modelname, tabletype))
+                             % (modelschema, modelname, tabletype))
 
         else:
             return False

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -565,8 +565,7 @@ class IdaDataBase(object):
         """
         modelname = ibmdbpy.utils.check_tablename(modelname)
         if '.' in modelname:
-            modelschema = modelname.split('.')[0]
-            modelname = modelname.split('.')[-1]
+            modelschema, modelschema = modelname.split('.')
         else:
             modelschema = self.current_schema
 

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -565,7 +565,7 @@ class IdaDataBase(object):
         """
         modelname = ibmdbpy.utils.check_tablename(modelname)
         if '.' in modelname:
-            modelschema, modelschema = modelname.split('.')
+            modelschema, modelname = modelname.split('.')
         else:
             modelschema = self.current_schema
 

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -581,7 +581,7 @@ class IdaDataBase(object):
             return True
 
         tablelist = self.show_tables(show_all=True)
-        tablelist= tablelist[(tablelist['TABSCHEMA']==modelschema) & (tablelist['TABNAME']==modelname)]
+        tablelist = tablelist[(tablelist['TABSCHEMA']==modelschema) & (tablelist['TABNAME']==modelname)]
         if len(tablelist):
              tabletype = tablelist['TYPE'].values[0]
              raise TypeError("%s.%s exists, but is not a model (of type '%s')"

--- a/ibmdbpy/frame.py
+++ b/ibmdbpy/frame.py
@@ -1495,6 +1495,7 @@ class IdaDataFrame(object):
         """
         Compute the covariance matrix, composed of covariance coefficients
         between all pairs of columns in self.
+        It must have at least two numeric columns.
 
         Returns
         -------
@@ -1511,6 +1512,7 @@ class IdaDataFrame(object):
         """
         Compute the correlation matrix, composed of correlation coefficients
         between all pairs of columns in self.
+        It must have at least two numeric columns.
 
         Parameters
         ----------
@@ -1598,6 +1600,7 @@ class IdaDataFrame(object):
     def mad(self):
         """
         Compute the mean absolute distance for all numeric columns of self.
+        It must have at least two numeric columns.
 
         Returns
         -------

--- a/ibmdbpy/geoFrame.py
+++ b/ibmdbpy/geoFrame.py
@@ -1028,22 +1028,9 @@ class IdaGeoDataFrame(IdaDataFrame):
 
         # Get the definitions of the columns, which will be the arguments for
         # the DB2GSE function
-        column1_for_db2gse = ida1.internal_state.columndict[ida1.geometry.column] 
-        if column1_for_db2gse[0] == '\"' and column1_for_db2gse[-1] == '\"':
-            column1_for_db2gse = column1_for_db2gse[1:-1]
-        column2_for_db2gse = ida2.internal_state.columndict[ida2.geometry.column] 
-        if column2_for_db2gse[0] == '\"' and column2_for_db2gse[-1] == '\"':
-            column2_for_db2gse = column2_for_db2gse[1:-1]
-
-        arguments_for_db2gse_function = []
-        if 'IDA1' or 'DB2GSE' in column1_for_db2gse:
-            arguments_for_db2gse_function.append(column1_for_db2gse) 
-        else:
-            arguments_for_db2gse_function.append('IDA1.'+column1_for_db2gse)
-        if 'IDA2' or 'DB2GSE' in column2_for_db2gse:
-            arguments_for_db2gse_function.append(column2_for_db2gse)
-        else:
-            arguments_for_db2gse_function.append('IDA2.'+column2_for_db2gse)
+        column1_for_db2gse = 'IDA1.\"%s\"' %(ida1.geometry.column)
+        column2_for_db2gse = 'IDA2.\"%s\"' %(ida2.geometry.column)
+        arguments_for_db2gse_function = [column1_for_db2gse, column2_for_db2gse]
         if additional_args is not None:
             for arg in additional_args:
                 arguments_for_db2gse_function.append(arg)

--- a/ibmdbpy/geoSeries.py
+++ b/ibmdbpy/geoSeries.py
@@ -2058,11 +2058,8 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         # user, the column definition is considered, instead of its alias
         # in the Ida object.
         column_for_db2gse = self.internal_state.columndict[self.column]
-        if column_for_db2gse[0] == '\"' and column_for_db2gse[-1] == '\"':
-                column_for_db2gse = column_for_db2gse[1:-1]
 
-        arguments_for_db2gse_function = []
-        arguments_for_db2gse_function.append(column_for_db2gse)
+        arguments_for_db2gse_function = [column_for_db2gse]
 
         if additional_args is not None:
             for arg in additional_args:
@@ -2076,23 +2073,25 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
             )
 
         new_columndict = OrderedDict()
-        new_columndict[result_column] = result_column
+        # remove double quotes to avoid problems with Python keys and SQL identifiers
+        result_column_key = result_column.replace('"', '')
+        new_columndict[result_column_key] = result_column
 
         idaseries._reset_attributes(["columns", "shape", "dtypes"])
-        idaseries.internal_state.columns = ['\"' + result_column + '\"']
+        idaseries.internal_state.columns = ['\"' + result_column_key + '\"']
 
         idaseries.internal_state.columndict = new_columndict
         idaseries.internal_state.update()
 
         # Set the column attribute of the new idaseries
-        idaseries.column = result_column
+        idaseries.column = result_column_key
         
         try:
             del(idaseries.columns)
         except:
             pass
         
-        if idaseries.dtypes.TYPENAME[result_column].find('ST_') == 0:
+        if idaseries.dtypes.TYPENAME[result_column_key].find('ST_') == 0:
             return IdaGeoSeries.from_IdaSeries(idaseries)
         else:
             return idaseries

--- a/ibmdbpy/geoSeries.py
+++ b/ibmdbpy/geoSeries.py
@@ -2073,7 +2073,9 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
             )
 
         new_columndict = OrderedDict()
-        # remove double quotes to avoid problems with Python keys and SQL identifiers
+        # result_column_key must not include double quotes because it is used as as Python key and as
+        # an SQL alias for the result column expression like in
+        # SELECT DB2GSE.ST_AREA("SHAPE",'KILOMETER') AS "DB2GSE.ST_AREA(SHAPE,'KILOMETER')" FROM SAMPLES.GEO_COUNTY
         result_column_key = result_column.replace('"', '')
         new_columndict[result_column_key] = result_column
 

--- a/ibmdbpy/learn/association_rules.py
+++ b/ibmdbpy/learn/association_rules.py
@@ -460,7 +460,7 @@ class AssociationRules(object):
             raise
         finally:
             idadf.internal_state._delete_view()
-            idadf._cursor.commit()
+            idadf.commit()
 
         self.labels_ = ibmdbpy.IdaDataFrame(idadf._idadb, outtable)
         return self.labels_
@@ -541,23 +541,19 @@ class AssociationRules(object):
         # In case the implementation of the IDA method changes, this may break
         # But still would not be difficult to fix 
 
-        assocpatterns = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_ASSOCPATTERNS"')
+        assocpatterns = self._idadb.ida_query('SELECT * FROM ' + modelname + '_ASSOCPATTERNS')
         assocpatterns.columns = ["ITEMSETID","ITEMID"]
         assocpatterns.columns = [x.upper() for x in assocpatterns.columns]
 
-        assocpatterns_stats = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_ASSOCPATTERNS_STATISTICS"')
+        assocpatterns_stats = self._idadb.ida_query('SELECT * FROM ' + modelname + '_ASSOCPATTERNS_STATISTICS')
         assocpatterns_stats.columns = ["ITEMSETID" , "LENGTH" , "COUNT"  , "SUPPORT" , "LIFT"  ,"PRUNED"]
         assocpatterns_stats.columns = [x.upper() for x in assocpatterns_stats.columns]
 
-        assocrules = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_ASSOCRULES"')
+        assocrules = self._idadb.ida_query('SELECT * FROM ' + modelname + '_ASSOCRULES')
         assocrules.columns = ["RULEID", "ITEMSETID", "BODYID", "HEADID", "CONFIDENCE", "PRUNED"]
         assocrules.columns = [x.upper() for x in assocrules.columns]
 
-        items = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_ITEMS"')
+        items = self._idadb.ida_query('SELECT * FROM ' + modelname + '_ITEMS')
         items.columns = ["ITEMID","ITEM","ITEMNAME","COUNT","SUPPORT"]
         items.columns = [x.upper() for x in items.columns]
 

--- a/ibmdbpy/learn/kmeans.py
+++ b/ibmdbpy/learn/kmeans.py
@@ -251,9 +251,8 @@ class KMeans(object):
         # Check or create a model name
         if self.modelname is None:
             self.modelname = idadf._idadb._get_valid_modelname('KMEANS_')
-        elif " " in self.modelname:
-            raise ValueError("Space in model name is not allowed")
         else:
+            self.modelname = ibmdbpy.utils.check_tablename(self.modelname)
             if idadf._idadb.exists_model(self.modelname):
                 idadf._idadb.drop_model(self.modelname)
 

--- a/ibmdbpy/learn/kmeans.py
+++ b/ibmdbpy/learn/kmeans.py
@@ -429,30 +429,26 @@ class KMeans(object):
         if self._idadb is None:
             raise IdaKMeansError("No KMeans model was trained before")
 
-        model_main = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_MODEL"')
+        model_main = self._idadb.ida_query('SELECT * FROM ' + modelname + '_MODEL')
         # Woraround for specific version of ODBC
         model_main.columns = ['MODELCLASS', 'COMPARISONTYPE', 'COMPARISONMEASURE', 'NUMCLUSTERS']
         model_main.columns = [x.upper() for x in model_main.columns]
 
 
-        col_info = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_COLUMNS"',)
+        col_info = self._idadb.ida_query('SELECT * FROM ' + modelname + '_COLUMNS',)
         col_info.columns = ['COLUMNNAME', 'DATATYPE', 'OPTYPE', 'USAGETYPE', 'COLUMNWEIGHT',
        'AUTOTRANSFORM', 'TRANSFORMEDCOLUMN', 'COMPAREFUNCTION', 'IMPORTANCE',
        'OUTLIERTREATMENT', 'LOWERLIMIT', 'UPPERLIMIT', 'CLOSURE',
        'STATISTICSTYPE']
         col_info.columns = [x.upper() for x in col_info.columns]
 
-        col_stats = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_COLUMN_STATISTICS"')
+        col_stats = self._idadb.ida_query('SELECT * FROM ' + modelname + '_COLUMN_STATISTICS')
         col_stats.columns = ['CLUSTERID', 'COLUMNNAME', 'CARDINALITY', 'MODE', 'MINIMUM', 'MAXIMUM',
        'MEAN', 'VARIANCE', 'VALIDFREQ', 'MISSINGFREQ', 'INVALIDFREQ',
        'IMPORTANCE']
         col_stats.columns = [x.upper() for x in col_stats.columns]
 
-        km_out_stat = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_CLUSTERS"')
+        km_out_stat = self._idadb.ida_query('SELECT * FROM ' + modelname + '_CLUSTERS')
         km_out_stat.columns = ['CLUSTERID', 'NAME', 'DESCRIPTION', 'SIZE', 'RELSIZE', 'WITHINSS']
         km_out_stat.columns = [x.upper() for x in km_out_stat.columns]
 

--- a/ibmdbpy/learn/naive_bayes.py
+++ b/ibmdbpy/learn/naive_bayes.py
@@ -484,14 +484,12 @@ class NaiveBayes(object):
         if self._idadb is None:
             raise IdaNaiveBayesError("The Naive Bayes model was not trained before.")
 
-        model_main = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_MODEL"')
+        model_main = self._idadb.ida_query('SELECT * FROM ' + modelname + '_MODEL')
         model_main.columns = ['ATTRIBUTE', 'VAL', 'CLASS', 'CLASSVALCOUNT', 'ATTRCLASSCOUNT',
        'CLASSCOUNT', 'TOTALCOUNT']
         model_main.columns = [x.upper() for x in model_main.columns]
 
-        disc = self._idadb.ida_query('SELECT * FROM "' +
-        self._idadb.current_schema + '"."' + modelname + '_DISCRANGES"')
+        disc = self._idadb.ida_query('SELECT * FROM ' + modelname + '_DISCRANGES')
         disc.columns = ['COLNAME', 'BREAK']
         disc.columns = [x.upper() for x in disc.columns]
 

--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -692,7 +692,7 @@ def corr(idadf, features=None,ignore_indexer=True):
     # TODO: catch case n <= 1
     numerical_columns = idadf._get_numerical_columns()
 
-    if not numerical_columns or len(numerical_columns) < 2 :
+    if len(numerical_columns) < 2 :
         print(idadf.name + " has less than two numeric columns")
         return
 

--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -637,7 +637,7 @@ def cov(idadf, other = None):
         raise TypeError("cov() missing 1 required positional argument: 'other'")
 
     columns = idadf._get_numerical_columns()
-    if not columns or len(columns) < 2:
+    if len(numerical_columns) < 2 :
         print(idadf.name + " has less than two numeric columns")
         return
 

--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -637,8 +637,8 @@ def cov(idadf, other = None):
         raise TypeError("cov() missing 1 required positional argument: 'other'")
 
     columns = idadf._get_numerical_columns()
-    if not columns:
-        print(idadf.name + " has no numeric columns")
+    if not columns or len(columns) < 2:
+        print(idadf.name + " has less than two numeric columns")
         return
 
     tuple_count = _numeric_stats(idadf, 'count', columns)
@@ -692,8 +692,8 @@ def corr(idadf, features=None,ignore_indexer=True):
     # TODO: catch case n <= 1
     numerical_columns = idadf._get_numerical_columns()
 
-    if not numerical_columns:
-        print(idadf.name + " has no numeric columns")
+    if not numerical_columns or len(numerical_columns) < 2 :
+        print(idadf.name + " has less than two numeric columns")
         return
 
     if ignore_indexer is True:
@@ -778,8 +778,8 @@ def mad(idadf):
     See IdaDataFrame.mad
     """
     columns = idadf._get_numerical_columns()
-    if not columns:
-        print(idadf.name + " has no numeric columns")
+    if not columns or len(columns) < 2 :
+        print(idadf.name + " has less than two numeric columns")
         return
 
     mean_tuple = _numeric_stats(idadf, "mean", columns)

--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -637,7 +637,7 @@ def cov(idadf, other = None):
         raise TypeError("cov() missing 1 required positional argument: 'other'")
 
     columns = idadf._get_numerical_columns()
-    if len(numerical_columns) < 2 :
+    if len(columns) < 2 :
         print(idadf.name + " has less than two numeric columns")
         return
 
@@ -778,7 +778,7 @@ def mad(idadf):
     See IdaDataFrame.mad
     """
     columns = idadf._get_numerical_columns()
-    if not columns or len(columns) < 2 :
+    if len(columns) < 2 :
         print(idadf.name + " has less than two numeric columns")
         return
 

--- a/ibmdbpy/tests/conftest.py
+++ b/ibmdbpy/tests/conftest.py
@@ -325,6 +325,27 @@ def idaview_tmp(request, idadb, idadf):
     idadb._create_view(idadf, "TEST_VIEW_ibmdbpy_TMP")
     return ibmdbpy.IdaDataFrame(idadb, "TEST_VIEW_ibmdbpy_TMP")
 
+@pytest.fixture(scope="function")
+def idageodf_county_view(request, idadb):
+    """
+    IdaGeoDataFrame to test geospatial methods with lowercase column names.
+    It refers to the view 'GEO_COUNTY_VIEW' where the columns of the
+    'SAMPLES.GEO_COUNTY' table have been renamed to their lowercase counterparts.
+    The view has one geometry column named 'shape' of type 'ST_MULTIPOLYGON'.
+    Don't use it for destructive nor non-destructive methods (modify columns).
+    """
+    def fin():
+        try:
+            idadb.drop_view("GEO_COUNTY_VIEW")
+            idadb.commit()
+        except:
+             pass
+    request.addfinalizer(fin)
+    idadb.ida_query('CREATE OR REPLACE VIEW GEO_COUNTY_VIEW AS ' +
+        '(SELECT "OBJECTID" as "objectid", "NAME" as "name", "SHAPE" as "shape"  FROM SAMPLES.GEO_COUNTY)')
+    idageodf = ibmdbpy.IdaGeoDataFrame(idadb, 'GEO_COUNTY_VIEW', indexer='objectid')
+    return idageodf
+
 @pytest.fixture(scope="session")
 def df(request):
     """

--- a/ibmdbpy/tests/test_base.py
+++ b/ibmdbpy/tests/test_base.py
@@ -94,9 +94,21 @@ class Test_DataBaseExploration(object):
     def test_idadb_exists_model_with_schema_positive(self, idadb, idadf_tmp):
         idadb.add_column_id(idadf_tmp, destructive=True)
         # Create a simple KMEANS model
-        kmeans = KMeans(n_clusters=3, modelname="MYSCHEMA.MODEL_58979457385")
+        kmeans = KMeans(n_clusters=3, modelname="MYSCHEMA.MODEL_45738558979")
         kmeans.fit(idadf_tmp)
-        assert(idadb.exists_model("MYSCHEMA.MODEL_58979457385") == 1)
+        assert(idadb.exists_model("MYSCHEMA.MODEL_45738558979") == 1)
+        try :
+            idadb.drop_model(kmeans.modelname)
+        except : pass
+
+    def test_idadb_exists_model_with_schema_positive_mixed_case(self, idadb, idadf_tmp):
+        idadb.add_column_id(idadf_tmp, destructive=True)
+        # Create a simple KMEANS model
+        kmeans = KMeans(n_clusters=3, modelname="mySchema.Model_85584573979")
+        kmeans.fit(idadf_tmp)
+        assert(idadb.exists_model("mySchema.Model_85584573979") == 1)
+        assert(idadb.exists_model("MYSCHEMA.MODEL_85584573979") == 1)
+        assert(idadb.exists_model("myschema.model_85584573979") == 1)
         try :
             idadb.drop_model(kmeans.modelname)
         except : pass

--- a/ibmdbpy/tests/test_base.py
+++ b/ibmdbpy/tests/test_base.py
@@ -47,9 +47,10 @@ class Test_DataBaseExploration(object):
             assert (list(df.columns) == ['MODELSCHEMA', 'MODELNAME', 'OWNER', 'CREATED', 'STATE',
                                          'MININGFUNCTION', 'ALGORITHM', 'USERCATEGORY'])
 
-    def test_idadb_exists_table_or_view_positive(self, idadb, idadf, idaview):
+    def test_idadb_exists_table_or_view_positive(self, idadb, idadf, idaview, idageodf_county_view):
         assert(idadb.exists_table_or_view(idadf.name) == 1)
         assert(idadb.exists_table_or_view(idaview.name) == 1)
+        assert(idadb.exists_table_or_view(idageodf_county_view.name) == 1)
 
     def test_idadb_exists_table_or_view_negative(self, idadb):
         assert(idadb.exists_table_or_view("NOT_EXISTING_DATA_FRAME_130530496_4860385960") == 0)
@@ -90,11 +91,26 @@ class Test_DataBaseExploration(object):
             idadb.drop_model(kmeans.modelname)
         except : pass
 
+    def test_idadb_exists_model_with_schema_positive(self, idadb, idadf_tmp):
+        idadb.add_column_id(idadf_tmp, destructive=True)
+        # Create a simple KMEANS model
+        kmeans = KMeans(n_clusters=3, modelname="MYSCHEMA.MODEL_58979457385")
+        kmeans.fit(idadf_tmp)
+        assert(idadb.exists_model("MYSCHEMA.MODEL_58979457385") == 1)
+        try :
+            idadb.drop_model(kmeans.modelname)
+        except : pass
+
     @flaky
     def test_idadb_exists_model_negative(self, idadb):
         if idadb.exists_model("MODEL_58979457385"):
             idadb.drop_model("MODEL_58979457385")
         assert(idadb.exists_model("MODEL_58979457385") == 0)
+
+    def test_idadb_exists_model_with_schema_negative(self, idadb):
+        if idadb.exists_model("SCHEMA_58979457385.MODEL_58979457385"):
+            idadb.drop_model("SCHEMA_58979457385.MODEL_58979457385")
+        assert(idadb.exists_model("SCHEMA_58979457385.MODEL_58979457385") == 0)
 
     def test_idadb_exists_model_error(self, idadb, idadf):
         with pytest.raises(TypeError):
@@ -143,7 +159,7 @@ class Test_DataBaseExploration(object):
     def test_idadb_is_model_negative(self, idadb, idadf, idaview):
         assert(idadb.is_model(idadf.name) == 0)
         assert(idadb.is_model(idaview.name) == 0)
-    #    assert(idadb.is_model("ST_INFORMTN_SCHEMA.ST_UNITS_OF_MEASURE") == 0)
+        assert(idadb.is_model("ST_INFORMTN_SCHEMA.ST_UNITS_OF_MEASURE") == 0)
 
     def test_idadb_is_model_error(self, idadb):
         with pytest.raises(ValueError):

--- a/ibmdbpy/tests/test_base_connexion.py
+++ b/ibmdbpy/tests/test_base_connexion.py
@@ -34,10 +34,7 @@ class Test_ConnectToDB(object):
         assert isinstance(idadb.data_source_name, six.string_types)
         assert isinstance(idadb._con_type, six.string_types)
         assert isinstance(idadb._idadfs, list)
-        if idadb._con_type == 'odbc':
-            assert isinstance(idadb._connection_string, six.string_types)
-        elif idadb._con_type == 'jdbc':
-            assert isinstance(idadb._connection_string, list)
+        assert isinstance(idadb._connection_string, six.string_types)
         assert(type(idadb._con).__name__ in ['Connection','instance'])
         assert(idadb._con_type in ["odbc", "jdbc"])
 

--- a/ibmdbpy/tests/test_base_connexion.py
+++ b/ibmdbpy/tests/test_base_connexion.py
@@ -34,7 +34,10 @@ class Test_ConnectToDB(object):
         assert isinstance(idadb.data_source_name, six.string_types)
         assert isinstance(idadb._con_type, six.string_types)
         assert isinstance(idadb._idadfs, list)
-        assert isinstance(idadb._connection_string, six.string_types)
+        if idadb._con_type =='odbc':
+          assert isinstance(idadb._connection_string, six.string_types)
+        elif idadb._con_type == 'jdbc':
+          assert(isinstance(idadb._connection_string, six.string_types) or isinstance(idadb._connection_string, list))
         assert(type(idadb._con).__name__ in ['Connection','instance'])
         assert(idadb._con_type in ["odbc", "jdbc"])
 

--- a/ibmdbpy/tests/test_geoFrame.py
+++ b/ibmdbpy/tests/test_geoFrame.py
@@ -198,3 +198,70 @@ class Test_IdaGeoDataFrame(object):
                 idageodf_county,
                 db2gse_function='DB2GSE.ST_AGEOSPATIALFUNCTION',
                 valid_types=['ST_POINT'])
+
+    def test_idageodf_max_distance(self, idageodf_county):
+         idageodf = idageodf_county
+         idageodf.set_geometry('SHAPE')
+         ida1 = idageodf[idageodf['NAME'] == 'Austin']
+         ida2 = idageodf[idageodf['NAME'] == 'Kent']
+         res = ida1.distance(ida2, 'KILOMETER')
+         max_dist = res['RESULT'].max()
+         assert(int(max_dist) == 2531)
+
+    def test_idageodf_max_distance_lc(self, idageodf_county_view):
+         idageodf = idageodf_county_view
+         idageodf.set_geometry('shape')
+         ida1 = idageodf[idageodf['name'] == 'Austin']
+         ida2 = idageodf[idageodf['name'] == 'Kent']
+         res = ida1.distance(ida2, 'kilometer')
+         max_dist = res['RESULT'].max()
+         assert(int(max_dist) == 2531)
+
+
+    def test_idageodf_max_distance_mbr(self, idageodf_county):
+         idageodf = idageodf_county
+         idageodf.set_geometry('SHAPE')
+         idageodf['MBR'] = idageodf.mbr()
+         idageodf.set_geometry('MBR')
+         ida1 = idageodf[idageodf['NAME'] == 'Austin']
+         ida2 = idageodf[idageodf['NAME'] == 'Kent']
+         res = ida1.distance(ida2, 'KILOMETER')
+         max_dist_mbr = res['RESULT'].max()
+         assert(int(max_dist_mbr) == 2519)
+
+    def test_idageodf_max_distance_mbr_lc(self, idageodf_county_view):
+         idageodf = idageodf_county_view
+         idageodf.set_geometry('shape')
+         idageodf['mbr'] = idageodf.mbr()
+         idageodf.set_geometry('mbr')
+         ida1 = idageodf[idageodf['name'] == 'Austin']
+         ida2 = idageodf[idageodf['name'] == 'Kent']
+         res = ida1.distance(ida2, 'kilometer')
+         max_dist_mbr = res['RESULT'].max()
+         assert(int(max_dist_mbr) == 2519)
+
+    def test_idageodf_max_area_union(self, idageodf_county):
+         idageodf = idageodf_county
+         idageodf.set_geometry('SHAPE')
+         idageodf['MBR'] = idageodf.mbr()
+         idageodf.set_geometry('MBR')
+         ida1 = idageodf[idageodf['NAME'] == 'Austin']
+         ida2 = idageodf[idageodf['NAME'] == 'Kent']
+         ida12_union = ida1.union(ida2)
+         ida12_union.set_geometry('RESULT')
+         ida12_union['MBR_UNION_AREA'] = ida12_union.area('KILOMETER')
+         max_area_union = ida12_union['MBR_UNION_AREA'].max()
+         assert(int(max_area_union) == 6596)
+
+    def test_idageodf_max_area_union_lc(self, idageodf_county_view):
+         idageodf = idageodf_county_view
+         idageodf.set_geometry('shape')
+         idageodf['mbr'] = idageodf.mbr()
+         idageodf.set_geometry('mbr')
+         ida1 = idageodf[idageodf['name'] == 'Austin']
+         ida2 = idageodf[idageodf['name'] == 'Kent']
+         ida12_union = ida1.union(ida2)
+         ida12_union.set_geometry('RESULT')
+         ida12_union['mbr_union_area'] = ida12_union.area('kilometer')
+         max_area_union = ida12_union['mbr_union_area'].max()
+         assert(int(max_area_union) == 6596)

--- a/ibmdbpy/tests/test_geoSeries.py
+++ b/ibmdbpy/tests/test_geoSeries.py
@@ -240,4 +240,34 @@ class Test_IdaGeoSeries(object):
                 db2gse_function = 'DB2GSE.ST_AGEOSPATIALFUNCTION',
                 valid_types = ['ST_POINT'])
 
-    
+    def test_idageoseries_area_km(self, idageodf_county):
+        idageodf = idageodf_county
+        idageodf.set_geometry('SHAPE')
+        idageodf['AREA_KM'] = idageodf.area(unit='KILOMETER')
+        max_area_km = idageodf['AREA_KM'].max()
+        assert(int(max_area_km)== 52073)
+
+    def test_idageoseries_area_km_lc(self, idageodf_county_view):
+        idageodf = idageodf_county_view
+        idageodf.set_geometry('shape')
+        idageodf['area_km'] = idageodf.area(unit='kilometer')
+        max_area_km = idageodf['area_km'].max()
+        assert(int(max_area_km)== 52073)
+
+    def test_idageoseries_area_km_mbr(self, idageodf_county):
+        idageodf = idageodf_county
+        idageodf.set_geometry('SHAPE')
+        idageodf['MBR'] = idageodf.mbr()
+        idageodf.set_geometry('MBR')
+        idageodf['AREA_KM_MBR'] = idageodf.area(unit='KILOMETER')
+        max_area_km_mbr = idageodf['AREA_KM_MBR'].max()
+        assert(int(max_area_km_mbr) == 100246)
+
+    def test_idageoseries_area_km_mbr_lc(self, idageodf_county_view):
+        idageodf = idageodf_county_view
+        idageodf.set_geometry('shape')
+        idageodf['mbr'] = idageodf.mbr()
+        idageodf.set_geometry('mbr')
+        idageodf['area_km_mbr'] = idageodf.area(unit='kilometer')
+        max_area_km_mbr = idageodf['area_km_mbr'].max()
+        assert(int(max_area_km_mbr) == 100246)

--- a/ibmdbpy/tests/test_statistics.py
+++ b/ibmdbpy/tests/test_statistics.py
@@ -187,10 +187,10 @@ class Test_DescriptiveStatistics(object):
 
     @pytest.mark.parametrize("f",
                              [IDADF.describe,
-                              pytest.param(IDADF.cov, marks=pytest.mark.xfail),
-                              pytest.param(IDADF.corr, marks=pytest.mark.xfail),
+                              IDADF.cov,
+                              IDADF.corr,
                               IDADF.quantile,
-                              pytest.param(IDADF.mad, marks=pytest.mark.xfail),
+                              IDADF.mad,
                               IDADF.min,
                               IDADF.max,
                               IDADF.count,


### PR DESCRIPTION
The changes fix issues https://github.com/ibmdbanalytics/ibmdbpy/issues/53 and https://github.com/ibmdbanalytics/ibmdbpy/issues/55. 
In addition it fixes SQL code generation problems related to lower case column names.

New testcases have been added to cover these changes. All are executed successfully:

```
============================= test session starts ==============================
platform linux -- Python 3.7.2, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3.7
cachedir: .pytest_cache
rootdir: /mnt/bludata0/scratch/ibmdbpy
plugins: flaky-3.6.1
collecting ... collected 492 items
test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_add_int PASSED [  0%]
test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_mul_int PASSED [  0%]
test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_div_int PASSED [  0%]
test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_sub_int PASSED [  0%]
test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_floordiv_int PASSED [  1%]

....

test_utils.py::Test_utils::test_check_viewname PASSED                    [ 99%]
test_utils.py::Test_utils::test_check_case PASSED                        [ 99%]
test_utils.py::Test_utils::test_reset_attributes PASSED                  [100%]

=============================== warnings summary ===============================
ibmdbpy/tests/test_aggregation.py::Test_aggregation::test_idadf_aggregation_1_column_add_int
ibmdbpy/tests/test_base_private.py::Test_IdaDataBase_PrivateMethods::test_idadb_get_valid_tablename_error
ibmdbpy/tests/test_base_private.py::Test_IdaDataBase_PrivateMethods::test_idadb_get_valid_viewname_error
ibmdbpy/tests/test_base_private.py::Test_IdaDataBase_PrivateMethods::test_idadb_get_valid_modelname_error
ibmdbpy/tests/test_base_table_manipulation.py::Test_DeleteDataBaseObjects::test_idadb_drop_view
ibmdbpy/tests/test_base_table_manipulation.py::Test_TableManipulation::test_idadb_rename_value_error
ibmdbpy/tests/test_utils.py::Test_utils::test_reset_attributes
  /usr/local/lib/python3.7/site-packages/ibmdbpy/utils.py:238: UserWarning: Mixed case names are not supported in database object names.
    warnings.warn("Mixed case names are not supported in database object names.", UserWarning)

ibmdbpy/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idadf_getitem_slice
ibmdbpy/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idaseries_getitem_slice
  /usr/local/lib/python3.7/site-packages/ibmdbpy/indexing.py:117: UserWarning: Row order is not guaranteed if no indexer was given and the dataset was not sorted
    warnings.warn("Row order is not guaranteed if no indexer" +

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===Flaky Test Report===

test_idadb_exists_model_negative passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
====== 487 passed, 1 skipped, 4 xpassed, 9 warnings in 201.52s (0:03:21) =======
```