### PR TITLE
Tb ibmdbpy changes2

### DIFF
--- a/docs/source/geospatial.rst
+++ b/docs/source/geospatial.rst
@@ -70,7 +70,7 @@ In the background, ibmdbpy-spatial looks for geometry columns in the table and b
 the area of each geometry.
 Here is the SQL request that was executed for this example:
 
-    SELECT *,ST_Area(SHAPE) AS "area" FROM SAMPLES.GEO_COUNTY;
+    SELECT \*,ST_Area(SHAPE) AS "area" FROM SAMPLES.GEO_COUNTY;
 
 
 It's as simple as that!

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -74,7 +74,7 @@ Name checking
 -------------
 .. autofunction:: check_tablename
 .. autofunction:: check_viewname
-.. autofunction:: check_case
+.. autofunction:: check_modelname
 
 Private functions
 =================

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -543,7 +543,9 @@ class IdaDataBase(object):
         Parameters
         ----------
         modelname : str
-            Name of the model to check.
+            Name of the model to check. It should contain only alphanumeric
+            characters and underscores. All lower case characters will be
+            converted to upper case characters.
 
         Returns
         -------
@@ -563,7 +565,7 @@ class IdaDataBase(object):
         >>> idadb.exists_model("NO_MODEL")
         TypeError : NO_TABLE exists but is not a model (of type '?')
         """
-        modelname = ibmdbpy.utils.check_tablename(modelname)
+        modelname = ibmdbpy.utils.check_modelname(modelname)
         if '.' in modelname:
             modelschema, modelname = modelname.split('.')
         else:
@@ -686,7 +688,9 @@ class IdaDataBase(object):
         Parameters
         ----------
         modelname : str
-            Name of the model to check.
+            Name of the model to check. It should contain only alphanumeric
+            characters and underscores. All lower case characters will be
+            converted to upper case characters.
 
         Returns
         -------
@@ -706,7 +710,7 @@ class IdaDataBase(object):
         >>> idadb.is_model("NOT_EXISTING")
         ValueError : NO_EXISTING doesn't exist in database
         """
-        modelname = ibmdbpy.utils.check_tablename(modelname)
+        modelname = ibmdbpy.utils.check_modelname(modelname)
 
         if '.' in modelname:
             modelname_noschema = modelname.split('.')[-1]
@@ -820,8 +824,10 @@ class IdaDataBase(object):
         dataframe : DataFrame
             Data to be uploaded, contained in a Pandas DataFrame.
         tablename : str, optional
-            Name to be given to the table created in the database. If not 
-            given, a valid tablename is generated (for example, DATA_FRAME_X 
+            Name to be given to the table created in the database.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If not given, a valid tablename is generated (for example, DATA_FRAME_X
             where X is a random number).
         clear_existing : bool
             If set to True, a table will be replaced when a table with the same 
@@ -1037,7 +1043,7 @@ class IdaDataBase(object):
         idadf : IdaDataFrame
             IdaDataFrame object referencing the table to rename.
         newname : str
-            Name to be given to self. Should contain only alphanumerical 
+            Name to be given to self. It should contain only alphanumeric
             characters and underscores. All lower case characters will be 
             converted to upper case characters. The new name should not already 
             exist in the database.

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -482,8 +482,8 @@ class IdaDataBase(object):
         """
         Check if a table exists in self.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         tablename : str
             Name of the table to check.
 
@@ -1168,8 +1168,8 @@ class IdaDataBase(object):
         """
         Add an ID column to an IdaDataFrame.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         idadf : IdaDataFrame
             IdaDataFrame object to which an ID column will be added
         column_id : str
@@ -1600,8 +1600,8 @@ class IdaDataBase(object):
         """
         Put every column name of a Pandas DataFrame in upper case.
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         dataframe: DataFrame
 
         Returns
@@ -1620,8 +1620,8 @@ class IdaDataBase(object):
         refers to the current schema.
 
 
-        Arguments
-        ---------
+        Parameters
+        ----------
         objectname : str
             Name of the object to process. Can be either under the form
             "SCHEMA.TABLE" or just "TABLE"

--- a/ibmdbpy/base.py
+++ b/ibmdbpy/base.py
@@ -1603,6 +1603,7 @@ class IdaDataBase(object):
         Arguments
         ---------
         dataframe: DataFrame
+
         Returns
         -------
         DataFrame
@@ -1651,7 +1652,7 @@ class IdaDataBase(object):
 
         Parameters
         ----------
-        prefix : str, default: "DATA_FRAME_"
+        prefix: str, default: "DATA_FRAME_"
             Prefix used to create the table name. The name is constructed using 
             this pattern : <prefix>_X where <prefix> corresponds to the string 
             parameter “prefix” capitalized and X corresponds to a pseudo 
@@ -1681,7 +1682,7 @@ class IdaDataBase(object):
         """
         Convenience function : Alternative name for get_valid_tablename.
 
-        The parameter prefix has its optional value changed to "VIEW_".
+        The parameter prefix has its optional value changed to "VIEW\_"".
 
         Examples
         --------
@@ -1700,7 +1701,7 @@ class IdaDataBase(object):
         """
         Convenience function : Alternative name for get_valid_tablename.
 
-        Parameter prefix has its optional value changed to "MODEL_".
+        Parameter prefix has its optional value changed to "MODEL\_".
 
         Examples
         --------

--- a/ibmdbpy/filtering.py
+++ b/ibmdbpy/filtering.py
@@ -39,7 +39,7 @@ class FilterQuery(object):
     FilterQuery objects also contain a logic that allows them to be
     combined, thus allowing complex filtering.
 
-      You can combine the following operators: |, &, ^ (OR, AND and XOR)
+      You can combine the following operators: \|, \&, \^ (OR, AND and XOR)
 
     Examples
     --------

--- a/ibmdbpy/frame.py
+++ b/ibmdbpy/frame.py
@@ -92,6 +92,8 @@ class IdaDataFrame(object):
             IdaDataBase instance which contains the connection to be used.
         tablename : str
             Name of the table to be opened in the database.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
         indexer : str, optional
             Name of the column that should be used as an index. This is
             optional. However, if no indexer is given, the order of rows issued
@@ -146,7 +148,7 @@ class IdaDataFrame(object):
         if not idadb.__class__.__name__ == "IdaDataBase":
             idadb_class = idadb.__class__.__name__
             raise TypeError("Argument 'idadb' is of type %s, expected : IdaDataBase"%idadb_class)
-        tablename = ibmdbpy.utils.check_case(tablename)
+        tablename = ibmdbpy.utils.check_tablename(tablename)
 
         #idadb._reset_attributes("cache_show_tables")
 
@@ -2411,5 +2413,3 @@ class IdaDataFrame(object):
             
 
 
-            
-        

--- a/ibmdbpy/frame.py
+++ b/ibmdbpy/frame.py
@@ -1468,6 +1468,7 @@ class IdaDataFrame(object):
         """
         A basic statistical summary about current IdaDataFrame. If at least one
         numerical column exists, the summary includes:
+
             * The count of non-missing values for each numerical column.
             * The mean for each numerical column.
             * The standart deviation for each numerical column.
@@ -2169,12 +2170,16 @@ class IdaDataFrame(object):
         Classify columns in the idaDataFrame into 4 classes: CATEGORICAL,
         STRING, NUMERIC or NONE. Use the database data type and a
         user-threshold “factor_threshold”:
-            * CATEGORICAL columns that have a number of distinct values that is greater than the factor_threshold should be considered a STRING.
-            * NUMERIC columns that have a number of distinct values that is smaller or equal to the factor_threshold should be considered CATEGORICAL.
+
+            * CATEGORICAL columns that have a number of distinct values that is greater
+              than the factor_threshold should be considered a STRING.
+            * NUMERIC columns that have a number of distinct values that is smaller or equal
+              to the factor_threshold should be considered CATEGORICAL.
 
         Returns
         -------
         DataFrame
+
             * Index is the columns of self.
             * Column "FACTORS" contains the number of distinct values.
             * Column "VALTYPE" contains the resulting class.
@@ -2227,8 +2232,8 @@ class IdaDataFrame(object):
         Get the columns of self that are considered as numerical. Their data
         type in the database determines whether these columns are numerical.
         The following data types are considered numerical:
-            'SMALLINT', 'INTEGER','BIGINT','REAL',
-            'DOUBLE','FLOAT','DECIMAL','NUMERIC'
+
+            SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, FLOAT, DECIMAL, NUMERIC.
 
         Returns
         -------
@@ -2249,7 +2254,8 @@ class IdaDataFrame(object):
         Get the columns of self that are considered as categorical. Their data
         type in the database determines whether these columns are categorical.
         The following data types are considered categorical:
-            "VARCHAR","CHARACTER", "VARGRAPHIC", "GRAPHIC", "CLOB".
+
+            VARCHAR,CHARACTER, VARGRAPHIC, GRAPHIC, CLOB.
 
         Returns
         -------
@@ -2413,3 +2419,5 @@ class IdaDataFrame(object):
             
 
 
+            
+        

--- a/ibmdbpy/geoFrame.py
+++ b/ibmdbpy/geoFrame.py
@@ -407,11 +407,12 @@ class IdaGeoDataFrame(IdaDataFrame):
         unit : str, optional
             Name of the unit, it is case-insensitive.
             If omitted, the following rules are used:
+
                 * If geometry is in a projected or geocentric coordinate
-                system, the linear unit associated with this coordinate system
-                is used.
+                  system, the linear unit associated with this coordinate system
+                  is used.
                 * If geometry is in a geographic coordinate system, the angular
-                unit associated with this coordinate system is used.
+                  unit associated with this coordinate system is used.
 
         References
         ----------

--- a/ibmdbpy/geoFrame.py
+++ b/ibmdbpy/geoFrame.py
@@ -298,7 +298,7 @@ class IdaGeoDataFrame(IdaDataFrame):
         Receives a column name to set as the "geometry" column of the
         IdaDataFrame.
 
-        Parameters:
+        Parameters
         -----------
         column_name : str
             Name of the column to be set as geometry column of the 

--- a/ibmdbpy/geoSeries.py
+++ b/ibmdbpy/geoSeries.py
@@ -201,11 +201,12 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         unit : str, optional
             Name of the unit, it is case-insensitive.
             If omitted, the following rules are used:
+
                 * If geometry is in a projected or geocentric coordinate
-                system, the linear unit associated with this coordinate system
-                is the default.
+                  system, the linear unit associated with this coordinate system
+                  is the default.
                 * If geometry is in a geographic coordinate system, the angular
-                unit associated with this coordinate system is the default.
+                  unit associated with this coordinate system is the default.
 
         Returns
         -------
@@ -219,12 +220,14 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         -----
         Restrictions on unit conversions: An error (SQLSTATE 38SU4) is returned
         if any of the following conditions occur:
+
             * The geometry is in an unspecified coordinate system and the unit
-            parameter is specified.
+              parameter is specified.
             * The geometry is in a projected coordinate system and an angular
-            unit is specified.
+              unit is specified.
             * The geometry is in a geographic coordinate system, but is not an
-            ST_Point value , and a linear unit is specified.
+              ST_Point value , and a linear unit is specified.
+
         # TODO: handle this SQLSTATE error
 
         References
@@ -550,6 +553,7 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         --------
         Sample to create in Db2, geometry column with data type ST_LineString
         Use this sample data for testing:
+
         >>> sample_lines = IdaGeoDataFrame(idadb, "SAMPLE_LINES", indexer = "ID", geometry  = "LOC")
         >>> sample_lines['end_point'] = sample_lines.end_point()
         >>> sample_lines.head()
@@ -777,11 +781,12 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         unit : str, optional
             Name of the unit, it is case-insensitive.
             If omitted, the following rules are used:
+
                 * If geometry is in a projected or geocentric coordinate
-                system, the linear unit associated with this coordinate system
-                is used.
+                  system, the linear unit associated with this coordinate system
+                  is used.
                 * If geometry is in a geographic coordinate system, the angular
-                unit associated with this coordinate system is used.
+                  unit associated with this coordinate system is used.
 
         Returns
         -------
@@ -795,12 +800,14 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         -----
         Restrictions on unit conversions: An error (SQLSTATE 38SU4) is returned
         if any of the following conditions occur:
+
             * The geometry is in an unspecified coordinate system and the unit
-            parameter is specified.
+              parameter is specified.
             * The geometry is in a projected coordinate system and an angular
-            unit is specified.
+              unit is specified.
             * The geometry is in a geographic coordinate system, and a linear
-            unit is specified.
+              unit is specified.
+
         # TODO: handle this SQLSTATE error
 
         References
@@ -897,11 +904,12 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         unit : str, optional
             Name of the unit, it is case-insensitive.
             If omitted, the following rules are used:
+
                 * If curve is in a projected or geocentric coordinate system,
-                the linear unit associated with this coordinate system is the
-                default.
+                  the linear unit associated with this coordinate system is the
+                  default.
                 * If curve is in a geographic coordinate system, the angular
-                unit associated with this coordinate system is the default.
+                  unit associated with this coordinate system is the default.
 
         Returns
         -------
@@ -915,12 +923,14 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         -----
         Restrictions on unit conversions: An error (SQLSTATE 38SU4) is returned
         if any of the following conditions occur:
+
             * The curve is in an unspecified coordinate system and the unit
-            parameter is specified.
+              parameter is specified.
             * The curve is in a projected coordinate system and an angular unit
-            is specified.
+              is specified.
             * The curve is in a geographic coordinate system, and a linear unit
-            is specified.
+              is specified.
+
         # TODO: handle this SQLSTATE error
 
         References
@@ -966,11 +976,12 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         unit : str, optional
             Name of the unit, it is case-insensitive.
             If omitted, the following rules are used:
+
                 * If surface is in a projected or geocentric coordinate system,
-                the linear unit associated with this coordinate system is the
-                default.
+                  the linear unit associated with this coordinate system is the
+                  default.
                 * If surface is in a geographic coordinate system, the angular
-                unit associated with this coordinate system is the default.
+                  unit associated with this coordinate system is the default.
 
         Returns
         -------
@@ -984,12 +995,14 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         -----
         Restrictions on unit conversions: An error (SQLSTATE 38SU4) is returned
         if any of the following conditions occur:
+
             * The geometry is in an unspecified coordinate system and the unit
-            parameter is specified.
+              parameter is specified.
             * The geometry is in a projected coordinate system and an angular
-            unit is specified.
+              unit is specified.
             * The geometry is in a geographic coordinate system and a linear
-            unit is specified.
+              unit is specified.
+
         # TODO: handle this SQLSTATE error
 
         References
@@ -1271,6 +1284,7 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         Examples
         --------
         Use sample table SAMPLE_POINTS, obtained with SQL script
+
         >>> sample_points = IdaGeoDataFrame(idadb, "SAMPLE_POINTS", indexer = "id", geometry = "LOC")
         >>> sample_points["is_3d"] = sample_points.is_3d()
         >>> sample_points[["LOC", "is_3d"]].head()
@@ -1384,7 +1398,8 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
 
         Examples
         --------
-        Max M, X, Y and Z        
+        Max M, X, Y and Z
+
         >>> sample_geometries = IdaGeoDataFrame(idadb, "SAMPLE_GEOMETRIES", indexer = "ID", geometry = "GEOMETRY")
         >>> sample_geometries["max_X"] = sample_geometries.max_x()
         >>> sample_geometries["max_Y"] = sample_geometries.max_y()

--- a/ibmdbpy/geoSeries.py
+++ b/ibmdbpy/geoSeries.py
@@ -39,15 +39,19 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
     It has geospatial methods based on Db2 Warehouse Spatial Extender (DB2GSE).
     
     Note on sample data used for the examples:
-    ------------------------------------------
-    Sample datasets available out of the box in Db2 Warehouse: GEO_TORNADO, GEO_COUNTY tables
-    Sample datasets which you can obtain yourself: SAMPLE_POLYGONS, SAMPLE_LINES,
-    SAMPLE_GEOMETRIES, SAMPLE_MLINES, SAMPLE_POINTS. --> See dedicated SQL script on 
-    https://github.com/ibmdbanalytics/ibmdbpy/blob/ibmdbpy_eva/ibmdbpy/sampledata/sql_script. 
-    You just need to copy this script into Db2 "RUN SQL" console to obtain these sample tables.
+
+        * Sample tables available out of the box in Db2 Warehouse:
+
+          GEO_TORNADO, GEO_COUNTY
+
+        * Sample tables which you can create by executing the SQL statements in
+          https://github.com/ibmdbanalytics/ibmdbpy/blob/master/ibmdbpy/sampledata/sql_script:
+
+          SAMPLE_POLYGONS, SAMPLE_LINES, SAMPLE_GEOMETRIES, SAMPLE_MLINES, SAMPLE_POINTS
+
     
-    Examples:
-    ---------
+    Examples
+    --------
     >>> idageodf = IdaGeoDataFrame(idadb, 'SAMPLES.GEO_COUNTY', indexer='OBJECTID', geometry = "SHAPE")
     >>> idageoseries = idageodf["SHAPE"]
     >>> idageoseries.dtypes
@@ -57,8 +61,8 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         | SHAPE | ST_MULTIPOLYGON   |
          ----------------------------
 
-    Notes:
-    ------
+    Notes
+    -----
     An IdaGeoSeries doesn't have an indexer attribute because geometries are
     unorderable in DB2 Spatial Extender.
     """
@@ -303,10 +307,7 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
 
     def convex_hull(self):
         """
-        
-        Note: theory
-        -------------
-        The convex hull of a shape, also called convex envelope or convex closure, is the smallest convex set that contains it. 
+        The convex hull of a shape, also called convex envelope or convex closure, is the smallest convex set that contains it.
         For example, if you have a bounded subset of points in the Euclidean space, the convex hull may be visualized as 
         the shape enclosed by an elastic band stretched around the outside points of the subset. 
         If vertices of the geometry do not form a convex, convexhull returns a null.
@@ -314,19 +315,19 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
         Valid types for the column in the calling IdaGeoSeries:
         ST_Geometry or one of its subtypes.
 
-        Note on the input type
-        -----------------------
-        If possible, the specific type of the returned geometry will be ST_Point, ST_LineString, or ST_Polygon. 
+        If possible, the specific type of the returned geometry will be ST_Point, ST_LineString, or ST_Polygon.
         The convex hull of a convex polygon with no holes is a single linestring, represented as ST_LineString. 
         The convex hull of a non convex polygon does not exit. 
         
         Returns
         -------
-        IdaGeoSeries. Returns an IdaGeoSeries containing geometries which are the convex hull of each
-        of the geometries in the calling IdaGeoSeries.
-        The resulting geometry is represented in the spatial reference system
-        of the given geometry.
-        For None geometries, for empty geometries and for non convex geometries the output is None.
+        IdaGeoSeries
+
+            Returns an IdaGeoSeries containing geometries which are the convex hull of each
+            of the geometries in the calling IdaGeoSeries.
+            The resulting geometry is represented in the spatial reference system
+            of the given geometry.
+            For None geometries, for empty geometries and for non convex geometries the output is None.
 
         References
         ----------
@@ -1981,8 +1982,8 @@ class IdaGeoSeries(ibmdbpy.IdaSeries):
     @lazy
     def linear_units(self):
         """
-        Returns:
-        --------
+        Returns
+        -------
         list of str
             The list of all allowed linear units that can be passed as option to geospatial methods.
         """

--- a/ibmdbpy/learn/association_rules.py
+++ b/ibmdbpy/learn/association_rules.py
@@ -46,9 +46,12 @@ class AssociationRules(object):
         Parameters
         ----------
         modelname : str
-            The name of the Association Rules model that is built. If the 
-            parameter corresponds to an existing model in the database, it 
-            will be replaced during the fitting step.
+            The name of the Association Rules model that will be built.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If it is not given, it will be generated automatically.
+            If the parameter corresponds to an existing model in the database,
+            it will be replaced during the fitting step.
         
         minsupport : float or integer, optional
             The minimum fraction (0.0 - 1.0) or the minimum number (above 1) of
@@ -72,7 +75,8 @@ class AssociationRules(object):
         Attributes
         ----------
                
-        nametable: Gets set at fit step. The name of the optional table which contains a mapping between the items from the input table and the item names. 
+        nametable: Gets set at fit step. The name of the optional table which contains a mapping
+            between the items from the input table and the item names.
             This attribute is set through the nametable option of the fit method.
             This table must contain at least two columns, where
             * The first column has the same name as the column that is
@@ -80,14 +84,14 @@ class AssociationRules(object):
             * The second column has the same name as the name that is
             defined in the namecol parameter
         
-        namecol : Gets set at fit step. The name of the optional column which contains item names as defined in the nametable attribute. 
+        namecol : Gets set at fit step. The name of the optional column which contains item names as defined in the nametable attribute.
             This attribute is set through the fit method and cannot be specified of the nametable parameter of fit is not specified.
         
-        outtable: Gets set at predict step, name of the optional output table in which the mapping between the input 
-            sequences and the associated rules or patterns is written. If the parameter corresponds to an existing table in the database, 
+        outtable: Gets set at predict step, name of the optional output table in which the mapping between the input
+            sequences and the associated rules or patterns is written. If the parameter corresponds to an existing table in the database,
             it is replaced.
         
-        type: Gets set at predict step. Type : str, optional, default : "rules". The type of information that is written in the output table. 
+        type: Gets set at predict step. Type : str, optional, default : "rules". The type of information that is written in the output table.
             The following values are possible: ‘rules’ and ‘patterns’;
         
         limit: Gets set at predict step int, optional, >=1, default: 1
@@ -193,8 +197,10 @@ class AssociationRules(object):
         item_id : str
             The column of the input table that identifies an item of the transaction.
         nametable : str, optional
-            The table that contains a mapping of the items in the input table and their names.
-            The table must contain at least two columns, where
+            The IdaDataFrame or the name of the table that contains a mapping of the items in the input table
+            and their names. The table name should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            The name table must contain at least two columns, where
             * The first column has the same name as the column that is
             contained in the item parameter of the input table
             * The second column has the same name as the name that is
@@ -223,6 +229,9 @@ class AssociationRules(object):
         self._idadf = idadf
         self._transaction_id = transaction_id
         self._item_id = item_id
+
+        if not (nametable is None or isinstance(nametable, ibmdbpy.frame.IdaDataFrame)):
+            nametable = ibmdbpy.utils.check_tablename(nametable)
         self.nametable = nametable
         self.namecol = namecol
 
@@ -363,8 +372,10 @@ class AssociationRules(object):
 
         outtable : str, optional
             The name of the output table in which the mapping between the input 
-            sequences and the associated rules or patterns is written. If the 
-            parameter corresponds to an existing table in the database, it is 
+            sequences and the associated rules or patterns is written.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If the parameter corresponds to an existing table in the database, it is
             replaced.
 
         transaction_id : str, optional
@@ -531,7 +542,7 @@ class AssociationRules(object):
         -----
         Needs better formatting instead of printing the tables
         """
-        modelname = ibmdbpy.utils.check_tablename(modelname)
+        modelname = ibmdbpy.utils.check_modelname(modelname)
 
         if self._idadb is None:
             raise IdaAssociationRulesError("No Association rules model was trained before.")

--- a/ibmdbpy/learn/association_rules.py
+++ b/ibmdbpy/learn/association_rules.py
@@ -56,9 +56,13 @@ class AssociationRules(object):
         minsupport : float or integer, optional
             The minimum fraction (0.0 - 1.0) or the minimum number (above 1) of
             transactions that must contain a pattern to be considered as frequent.
-            Default: system-determined
-            Range: >0.0 and <1.0 for a minimum fraction
-                   >1 for a minimum number of transactions.
+
+            Default:
+                * system-determined
+
+            Range:
+                * >0.0 and <1.0 for a minimum fraction
+                * >1 for a minimum number of transactions.
         
         maxlen : int, optional, >=2, default: 5
             The maximum length of a pattern or a rule, that is,
@@ -79,19 +83,25 @@ class AssociationRules(object):
             between the items from the input table and the item names.
             This attribute is set through the nametable option of the fit method.
             This table must contain at least two columns, where
+
             * The first column has the same name as the column that is
-            contained in the item parameter of the input table
+              contained in the item parameter of the input table
             * The second column has the same name as the name that is
-            defined in the namecol parameter
+              defined in the namecol parameter
         
-        namecol : Gets set at fit step. The name of the optional column which contains item names as defined in the nametable attribute.
-            This attribute is set through the fit method and cannot be specified of the nametable parameter of fit is not specified.
+        namecol : Gets set at fit step. The name of the optional column which
+            contains item names as defined in the nametable attribute.
+            This attribute is set through the fit method and cannot be specified
+            of the nametable parameter of fit is not specified.
         
-        outtable: Gets set at predict step, name of the optional output table in which the mapping between the input
-            sequences and the associated rules or patterns is written. If the parameter corresponds to an existing table in the database,
+        outtable: Gets set at predict step, name of the optional output table
+            in which the mapping between the input
+            sequences and the associated rules or patterns is written.
+            If the parameter corresponds to an existing table in the database,
             it is replaced.
         
-        type: Gets set at predict step. Type : str, optional, default : "rules". The type of information that is written in the output table.
+        type: Gets set at predict step. Type : str, optional, default : "rules".
+            The type of information that is written in the output table.
             The following values are possible: ‘rules’ and ‘patterns’;
         
         limit: Gets set at predict step int, optional, >=1, default: 1
@@ -201,10 +211,11 @@ class AssociationRules(object):
             and their names. The table name should contain only alphanumeric characters and underscores.
             All lower case characters will be converted to upper case characters.
             The name table must contain at least two columns, where
+
             * The first column has the same name as the column that is
-            contained in the item parameter of the input table
+              contained in the item parameter of the input table
             * The second column has the same name as the name that is
-            defined in the namecol parameter
+              defined in the namecol parameter
         namecol : str, optional
             The column that contains the item name that is defined in the
             nametable parameter. You cannot specify this parameter if the
@@ -290,10 +301,12 @@ class AssociationRules(object):
             least one of the listed items must be contained in a rule or
             pattern to be kept.
             For rules, the following conditions apply:
-                * To indicate that the item must be contained in the head of
-                then rule, the item names can be succeeded by :h or :head.
-                * To indicate that the item must be contained in the body of
-                the rule, the item names can be succeeded by :b or :body
+
+                * To indicate that the item must be contained in the head of then rule,
+                  the item names can be succeeded by :h or :head.
+                * To indicate that the item must be contained in the body of the rule,
+                  the item names can be succeeded by :b or :body
+
             If this parameter is not specified, no constraint is applied.
 
         itemsout : str or list, optional
@@ -499,11 +512,11 @@ class AssociationRules(object):
     def describe(self, detail=False):
         """
         Parameters
-        ------
+        ----------
         detail: bool, optional. False by default.
         
         Returns
-        -----
+        -------
         Returns a description of Association Rules Model. If detail is set to False, then
         only a table with the summary of the rules is displayed, if detail is set to True,
         then thenintermediary tables are shown too.
@@ -526,6 +539,7 @@ class AssociationRules(object):
         """
         Retrieve information about the model to print the results. The 
         Association Rules IDAX function stores its result in 4 tables:
+
             * <MODELNAME>_ASSOCPATTERNS
             * <MODELNAME>_ASSOCPATTERNS_STATISTICS
             * <MODELNAME>_ASSOCRULES

--- a/ibmdbpy/learn/kmeans.py
+++ b/ibmdbpy/learn/kmeans.py
@@ -84,11 +84,16 @@ class KMeans(object):
 
             The following values are allowed: ‘none’, ‘columns’, ‘values:n’, and ‘all’:
                 * If statistics='none' is specified, no statistics are collected.
-                * If statistics='columns' is specified, statistics on the columns of the input table are collected, for example, mean values.
-                * If statistics='values:n' is specified, and if n is a positive number, statistics on the columns and the column values are collected.
+                * If statistics='columns' is specified, statistics on the columns
+                  of the input table are collected, for example, mean values.
+                * If statistics='values:n' is specified, and if n is a positive number, statistics
+                  on the columns and the column values are collected.
+
                     Up to <n> column value statistics are collected.
-                        * If a nominal column contains more than <n> values, only the <n> most frequent column statistics are kept.
-                        * If a numeric column contains more than <n> values, the values are discretized, and the statistics are collected on the discretized values.
+                        * If a nominal column contains more than <n> values,
+                          only the <n> most frequent column statistics are kept.
+                        * If a numeric column contains more than <n> values, the values
+                          are discretized, and the statistics are collected on the discretized values.
                 * statistics=all is identical to statistics=values:100.
 
         Attributes
@@ -208,7 +213,9 @@ class KMeans(object):
             The columns of the input table that have specific properties, which
             are separated by a semi-colon (;).
             Each column is succeeded by one or more of the following properties:
-                * By type nominal (':nom') or by type continuous (':cont'). By default, numerical types are continuous, and all other types nominal.
+
+                * By type nominal (':nom') or by type continuous (':cont'). By default,
+                  numerical types are continuous, and all other types nominal.
                 * By role ':id', ':target', ':input', or ':ignore'.
 
             If this parameter is not specified, all columns of the input table
@@ -423,6 +430,7 @@ class KMeans(object):
         """
         Retrieve information about the model to print the results. The KMEANS 
         IDAX function stores its result in 4 tables:
+
             * <MODELNAME>_MODEL
             * <MODELNAME>_COLUMNS
             * <MODELNAME>_COLUMN_STATISTICS

--- a/ibmdbpy/learn/kmeans.py
+++ b/ibmdbpy/learn/kmeans.py
@@ -58,10 +58,12 @@ class KMeans(object):
             Range : > 2
 
         modelname : str, optional
-            The name of the clustering model that is built. If it is not given, 
-            it is generated automatically. If the parameter corresponds to an 
-            existing model in the database, it is replaced during the fitting 
-            step.
+            The name of the clustering model that will be built.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If it is not given, it will be generated automatically.
+            If the parameter corresponds to an existing model in the database,
+            it is replaced during the fitting step.
 
 
         max_iter : int, > 1 and <= 1000, default = 5
@@ -224,9 +226,11 @@ class KMeans(object):
             specified, all columns are input columns.
 
         colPropertiesTable : idaDataFrame, optional
-            The input IdaDataFrame where the properties of the columns of the 
-            input IdaDataFrame (idadf) are stored. If this parameter is not 
-            specified, the column properties of the input table column 
+            The input IdaDataFrame or name of the table where the properties of the
+            columns of the input IdaDataFrame (idadf) are stored.
+            The table name should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If this parameter is not specified, the column properties of the input table column
             properties are detected automatically.
 
         verbose : bool, default: False
@@ -252,9 +256,16 @@ class KMeans(object):
         if self.modelname is None:
             self.modelname = idadf._idadb._get_valid_modelname('KMEANS_')
         else:
-            self.modelname = ibmdbpy.utils.check_tablename(self.modelname)
+            self.modelname = ibmdbpy.utils.check_modelname(self.modelname)
             if idadf._idadb.exists_model(self.modelname):
                 idadf._idadb.drop_model(self.modelname)
+
+        self.incolumn = incolumn
+        self.coldeftype = coldeftype
+        self.coldefrole = coldefrole
+        if not (colPropertiesTable is None or isinstance(colPropertiesTable, ibmdbpy.frame.IdaDataFrame)):
+            colPropertiesTable = ibmdbpy.utils.check_tablename(colPropertiesTable)
+        self.colPropertiesTable = colPropertiesTable
 
         # Create a temporay view
         idadf.internal_state._create_view()
@@ -315,6 +326,8 @@ class KMeans(object):
 
         outtable : str
             The name of the output table where the assigned clusters are stored.
+            It should contain only alphanumeric characters and underscores.
+            All lower case characters will be converted to upper case characters.
             If this parameter is not specified, it is generated automatically.
             If the parameter corresponds to an existing table in the database,
             it is replaced.
@@ -423,7 +436,7 @@ class KMeans(object):
         verbose : bol, default: False
             Verbosity mode.
         """
-        modelname = ibmdbpy.utils.check_tablename(modelname)
+        modelname = ibmdbpy.utils.check_modelname(modelname)
 
         if self._idadb is None:
             raise IdaKMeansError("No KMeans model was trained before")

--- a/ibmdbpy/learn/naive_bayes.py
+++ b/ibmdbpy/learn/naive_bayes.py
@@ -52,10 +52,10 @@ class NaiveBayes(object):
             If the parameter corresponds to an existing model in the database,
             it is replaced during the fitting step.
 
-
         disc : str, optional, default: ew
             Determine the automatic discretization of all continuous attributes. 
-            The following values are allowed: ef, em, ew, and ewn. 
+            The following values are allowed: ef, em, ew, and ewn.
+
                 * disc=ef
                     Equal-frequency discretization.
                     An unsupervised discretization algorithm that uses the equal
@@ -92,9 +92,11 @@ class NaiveBayes(object):
             The columns of the input table that have specific properties,
             which are separated by a semi-colon (;). Each column is succeeded
             by one or more of the following properties:
-                * By type nominal (':nom') or by type continuous (':cont'). By default, numerical types are continuous, and all other types are nominal.
+
+                * By type nominal (':nom') or by type continuous (':cont'). By default,
+                  numerical types are continuous, and all other types are nominal.
                 * By role ':id', ':target', ':input', or ':ignore'.
-        
+
         coldeftype: Get set at fit step; str, optional
             The default type of the input table columns.
             The following values are allowed: 'nom' and 'cont'.
@@ -240,7 +242,9 @@ class NaiveBayes(object):
             The columns of the input table that have specific properties,
             which are separated by a semi-colon (;). Each column is succeeded
             by one or more of the following properties:
-                * By type nominal (':nom') or by type continuous (':cont'). By default, numerical types are continuous, and all other types are nominal.
+
+                * By type nominal (':nom') or by type continuous (':cont'). By default,
+                  numerical types are continuous, and all other types are nominal.
                 * By role ':id', ':target', ':input', or ':ignore'.
 
             If this parameter is not specified, all columns of the input table have default properties.
@@ -450,11 +454,11 @@ class NaiveBayes(object):
     def describe(self, detail=False):
         """
         Parameters
-        -------
+        ----------
         detail: bool, optional. False by default. 
         
         Returns
-        ------
+        -------
         Return a description of Naives Bayes.
         If False, only the a priori probabilities of each class are returned, 
         displayed in table format. If True, then intermediary tables are shown.
@@ -475,6 +479,7 @@ class NaiveBayes(object):
         """
         Retrieve information about the model to print the results. The Naive 
         Bayes IDAX function stores its result in 2 tables:
+
             * <MODELNAME>_MODEL
             * <MODELNAME>_DISCRANGES
 

--- a/ibmdbpy/learn/naive_bayes.py
+++ b/ibmdbpy/learn/naive_bayes.py
@@ -45,10 +45,12 @@ class NaiveBayes(object):
         Parameters
         ----------
         modelname : str, optional
-            The name of the Naive Bayes model that will be built. If no name is 
-            specified, it will be generated automatically. If the parameter 
-            corresponds to an existing model in the database, it is replaced 
-            during the fitting step.
+            The name of the Naive Bayes model that will be built.
+            Should contain only alphanumerical characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If no name is specified, it will be generated automatically.
+            If the parameter corresponds to an existing model in the database,
+            it is replaced during the fitting step.
 
 
         disc : str, optional, default: ew
@@ -105,8 +107,8 @@ class NaiveBayes(object):
             If the parameter is not specified, all columns are input columns.
         
         colpropertiestable: Get set at fit step; str, optional
-            The input table where the properties of the columns of the input table are stored.
-            If this parameter is not specified, the column properties of the input table
+            The name of the input table where the properties of the columns of the input table
+            are stored. If this parameter is not specified, the column properties of the input table
             column properties are detected automatically.
         
         outable: Get set at predict step; str, optional
@@ -166,7 +168,7 @@ class NaiveBayes(object):
         self.outtableProb = None
         self.mestimation = None
 
-        self.modelname = modelname
+        self.modelname = ibmdbpy.utils.check_modelname(modelname)
         self.disc = disc
         self.bins = bins
 
@@ -255,7 +257,10 @@ class NaiveBayes(object):
             If the parameter is not specified, all columns are input columns.
 
         colpropertiestable : str, optional
-            The input table where the properties of the columns of the input table are stored.
+            The input IdaDataFrame or the name of the table where the properties of the
+            columns of the input IdaDataFrame (idadf) are stored.
+            The table name should contain only alphanumerical characters and underscores.
+            All lower case characters will be converted to upper case characters.
             If this parameter is not specified, the column properties of the input table
             column properties are detected automatically.
 
@@ -285,13 +290,15 @@ class NaiveBayes(object):
         self.incolumn = incolumn
         self.coldeftype = coldeftype
         self.coldefrole = coldefrole
+        if not (colpropertiestable is None or isinstance(colpropertiestable, ibmdbpy.frame.IdaDataFrame)):
+            colpropertiestable = ibmdbpy.utils.check_tablename(colpropertiestable)
         self.colpropertiestable = colpropertiestable
 
         # Check or create a model name, drop it if it already exists.
         if self.modelname is None:
             self.modelname = idadf._idadb._get_valid_modelname('NAIVEBAYES_')
         else:
-            self.modelname = ibmdbpy.utils.check_tablename(self.modelname)
+            self.modelname = ibmdbpy.utils.check_modelname(self.modelname)
             if idadf._idadb.exists_model(self.modelname):
                 idadf._idadb.drop_model(self.modelname)
 
@@ -345,15 +352,19 @@ class NaiveBayes(object):
             procedure to build the model.
 
         outtable : str, optional
-            The name of the output table where the predictions are stored. If
-            this parameter is not specified, it is generated automatically. If
+            The name of the output table where the predictions are stored.
+            It should contain only alphanumerical characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If this parameter is not specified, it is generated automatically. If
             the parameter corresponds to an existing table in the database, it
             will be replaced.
 
         outtableProb : str, optional
-            The output table where the probabilities for each of the classes are stored.
-            If this parameter is not specified, the table is not created. If
-            the parameter corresponds to an existing table in the database, it
+            The name of the output table where the probabilities for each of the classes are stored.
+            It should contain only alphanumerical characters and underscores.
+            All lower case characters will be converted to upper case characters.
+            If this parameter is not specified, the table is not created.
+            If the parameter corresponds to an existing table in the database, it
             will be replaced.
 
         mestimation : flag, default: False
@@ -479,7 +490,7 @@ class NaiveBayes(object):
         -----
         Needs better formatting instead of printing the tables.
         """
-        modelname = ibmdbpy.utils.check_tablename(modelname)
+        modelname = ibmdbpy.utils.check_modelname(modelname)
 
         if self._idadb is None:
             raise IdaNaiveBayesError("The Naive Bayes model was not trained before.")

--- a/ibmdbpy/statistics.py
+++ b/ibmdbpy/statistics.py
@@ -244,7 +244,8 @@ def _count_level(idadf, columnlist=None):
 
     Notes
     -----
-    The function assumes the follwing:
+    The function assumes the following:
+
         * The columns given as parameter exists in the IdaDataframe.
         * The parameter columnlist is an optional list.
         * Columns are referenced by their own name (character string).
@@ -285,6 +286,7 @@ def _count_level_groupby(idadf, columnlist=None):
     Notes
     -----
     The function assumes the follwing:
+
         * The columns given as parameter exists in the IdaDataframe.
         * The parameter columnlist is a optional and is a list.
         * Columns are referenced by their own name (character string).
@@ -313,8 +315,10 @@ def _factors_count(idadf, columnlist, valuelist=None):
     valuelist : list
         List of column names that exist in self.
 
-    Assumptions
-    -----------
+     Notes
+     -----
+     The function assumes the following:
+
         * The columns given as parameter exists in the IdaDataframe
         * The parameter columnlist is a optional and is a list
         * Columns are referenced by their own name (character string)
@@ -356,8 +360,10 @@ def _factors_sum(idadf, columnlist, valuelist):
     valuelist : list
         List of column names that exist in self.
 
-    Assumptions
-    -----------
+    Notes
+    -----
+    The function assumes the following:
+
         * The columns given as parameter exists in the IdaDataframe
         * The parameter columnlist is a optional and is a list
         * Columns are referenced by their own name (character string)
@@ -395,8 +401,10 @@ def _factors_avg(idadf, columnlist, valuelist):
     valuelist : list
         List of column names that exist in self.
 
-    Assumptions
-    -----------
+    Notes
+    -----
+    The function assumes the following:
+
         * The columns given as parameter exists in the IdaDataframe
         * The parameter columnlist and valuelist are array-like
         * Columns are referenced by their own name (character string)

--- a/ibmdbpy/utils.py
+++ b/ibmdbpy/utils.py
@@ -211,25 +211,27 @@ def check_tablename(tablename):
 
     Notes
     -----
-        Table names should consist of upper case characters or numbers that can 
+        Table names should consist of upper case characters or numbers that can
         be separated by underscores (“_”) characters.
     """
-    tablename = check_case(tablename)
-    if not all([(char.isalnum() | (char == '_') | (char == '.')) for char in tablename]):
-        raise ValueError("Table name is not valid, only alphanumeric characters and underscores are allowed.")
-    if tablename.count(".") > 1:
-        raise ValueError("Table name is not valid, only one '.' character is allowed.")
-    return tablename
+    return _check_database_objectname(tablename, 'Table')
 
 def check_viewname(viewname):
     """
-    Convenience function. Just an alternative name to check_tablename for 
-    checking view names, which have the same prerequisites as tablenames. See 
-    the check_tablename documentation.
+    Convenience function for checking view names, which have the same prerequisites as table names.
+    See the check_tablename documentation.
     """
-    return check_tablename(viewname)
+    return _check_database_objectname(viewname, 'View')
 
-def check_case(name):
+def check_modelname(modelname):
+    """
+    Convenience function for checking model names, which have the same prerequisites as table names.
+    See the check_tablename documentation.
+    """
+    return _check_database_objectname(modelname, 'Model')
+
+
+def _check_case(name):
     """
     Check if the name given as parameter is in upper case and convert it to 
     upper cases.
@@ -237,6 +239,38 @@ def check_case(name):
     if name != name.upper():
         warnings.warn("Mixed case names are not supported in database object names.", UserWarning)
     return name.upper()
+
+
+def _check_database_objectname(tablename, objecttype):
+    """
+    Check if a string is upper case. This function converts the string to upper
+    case and checks if it is a valid database object (table, view or model) name.
+
+    Parameters
+    ----------
+    tablename : str
+        string to be checked.
+
+    objecttype : str
+            ''
+
+    Returns
+    -------
+    str
+        Checked and upper cased database object name.
+
+    Notes
+    -----
+        Database object names should consist of upper case characters or numbers that can
+        be separated by underscores (“_”) characters.
+    """
+    tablename = _check_case(tablename)
+    if not all([(char.isalnum() | (char == '_') | (char == '.')) for char in tablename]):
+        raise ValueError("%s name '%s' is not valid, only alphanumeric characters and underscores are allowed."%(objecttype, tablename))
+    if tablename.count(".") > 1:
+        raise ValueError("%s name '%s' is not valid, only one '.' character is allowed."%(objecttype, tablename))
+    return tablename
+
 
 def _convert_dtypes(idadf, data):
     """

--- a/ibmdbpy/utils.py
+++ b/ibmdbpy/utils.py
@@ -157,10 +157,11 @@ def to_nK(dataframe, nKrow):
 
     Notes
     -----
-    * If the dataset is smaller than nKrow, it will be imputed randomly 
-    with some existing rows, otherwise ve return a random sample
 
-    * Legagy from Benchmark submodule
+    * If the dataset is smaller than nKrow, it will be imputed randomly 
+      with some existing rows, otherwise a random sample is returned
+    * Legacy from Benchmark submodule
+
     """
     if nKrow < 1:
         raise ValueError("n should be an integer with minimum value 1")

--- a/ibmdbpy/utils.py
+++ b/ibmdbpy/utils.py
@@ -127,7 +127,7 @@ def silent(function):
 
     Notes
     -----
-    * Legagy from Benchmark submodule
+    * Legacy from Benchmark submodule
 
     """
     @wraps(function)
@@ -182,10 +182,10 @@ def extend_dataset(df, n):
     """
     Extend a dataframe horizontaly by duplicating its columns n times
 
-    Note
-    ----
+    Notes
+    -----
 
-    * Legagy from Benchmark submodule
+    * Legacy from Benchmark submodule
     """
     df_2 = deepcopy(df)
     df_out = deepcopy(df)


### PR DESCRIPTION
The FVT tests are executed successfully
https://hyc-idax-jenkins.swg-devops.com/view/Custom%20FVT/job/FVT_CUSTOM_IBMDBPY/lastBuild/
and the documentation is generated with only one remaining warning:
```
$ make html 
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v2.4.4
loading translations [english]... not available for built-in messages
making output directory... done
WARNING: html_static_path entry '_static' does not exist
loading intersphinx inventory from https://docs.python.org/objects.inv...
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 15 source files that are out of date
updating environment: [new config] 15 added, 0 changed, 0 removed
reading sources... [100%] utils                                                                                                      
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] utils                                                                                                       
generating indices...  genindex py-modindexdone
highlighting module code... [100%] ibmdbpy.utils                                                                                     
writing additional pages...  search/Users/toni/anaconda3/lib/python3.7/site-packages/sphinx_rtd_theme/search.html:20: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  {{ super() }}
done
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 1 warning.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
```