### PR TITLE
Fix of twine check error: Anonymous hyperlink mismatch: 0 references …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ The ibmdbpy project is compatible with Python releases 2.7 up to 3.6 and can be 
 
 The project is still at an early stage and many of its features are still in development. However, several experiments have already demonstrated that it provides significant performance advantages when operating on medium or large amounts of data, that is, on tables of 1 million rows or more.
 
-The latest version of ibmdbpy is available on the `Python Package Index`_ and Github_.
+The latest version of ibmdbpy is available on the `Python Package Index`__ and Github_.
 
 __ https://pypi.python.org/pypi/ibmdbpy
 


### PR DESCRIPTION
…but 1 targets.

It is caused by a missing underscore after ``Python Package Index``_
and prevents the upload of the ibmdbpy package to https://test.pypi.org.

Before the change we have:
> The latest version of ibmdbpy is available on the `Python Package Index`_ and Github.

and after that:

> The latest version of ibmdbpy is available on the Python Package Index and Github.

where the Hyperlink on "python Package Index" works.