### PR TITLE
Fixes depricated pandas del data.index.name

### DIFF
--- a/ibmdbpy/frame.py
+++ b/ibmdbpy/frame.py
@@ -1153,7 +1153,7 @@ class IdaDataFrame(object):
                 data.set_index(data.columns[-1], inplace=True)  # Set the index
                 data.columns = self.columns
 
-            del data.index.name
+            data.index.name = None
             #            data = ibmdbpy.utils._convert_dtypes(self, data)
             if isinstance(self, ibmdbpy.IdaSeries):
                     data = pd.Series(data[data.columns[0]])
@@ -2141,7 +2141,7 @@ class IdaDataFrame(object):
         data.columns = ["COLNAME", "TYPENAME"]
         data.columns = [x.upper() for x in data.columns]
         data.set_index(keys='COLNAME', inplace=True)
-        del data.index.name
+        data.index.name = None
         return data
 
     def _reset_attributes(self, attributes):


### PR DESCRIPTION
Fixes error below:
```
      1 idadf = IdaDataFrame(idadb, 'TPCDS.CUSTOMER')
      2 idadf.shape
----> 3 idadf.head()

~/ibmdbpy/ibmdbpy/internals.py in wrapper(self, *args, **kwds)
     55                 self.internal_state.viewstack.append("(" + self.internal_state.get_state() + ")")
     56             try:
---> 57                 result = function(self, *args, **kwds)
     58             except:
     59                 raise

~/ibmdbpy/ibmdbpy/frame.py in head(self, nrow, sort)
   1068                     if sort:
   1069                         column = self.columns[0]
-> 1070                         if self._get_numerical_columns():
   1071                             column = self._get_numerical_columns()[0]
   1072                         order = " ORDER BY \"" + column + "\" ASC"

~/ibmdbpy/ibmdbpy/frame.py in _get_numerical_columns(self)
   2248         num = ['SMALLINT', 'INTEGER', 'BIGINT', 'REAL',
   2249                             'DOUBLE', 'FLOAT', 'DECIMAL', 'NUMERIC']
-> 2250         return list(self.dtypes.loc[self.dtypes['TYPENAME'].isin(num)].index)
   2251 
   2252     def _get_categorical_columns(self):

/opt/conda/lib/python3.8/site-packages/lazy/lazy.py in __get__(self, inst, inst_cls)
     26             name = '_%s%s' % (inst_cls.__name__, name)
     27 
---> 28         value = self.__func(inst)
     29         inst.__dict__[name] = value
     30         return value

~/ibmdbpy/ibmdbpy/internals.py in wrapper(self, *args, **kwds)
     65             self.internal_state._create_view()
     66             try:
---> 67                 result = function(self, *args, **kwds)
     68             except:
     69                 raise

~/ibmdbpy/ibmdbpy/frame.py in dtypes(self)
    293         """
    294         #import pdb ; pdb.set_trace()
--> 295         return self._get_columns_dtypes()
    296 
    297     @lazy

~/ibmdbpy/ibmdbpy/frame.py in _get_columns_dtypes(self)
   2142         data.columns = [x.upper() for x in data.columns]
   2143         data.set_index(keys='COLNAME', inplace=True)
-> 2144         del data.index.name
   2145         return data
   2146 

AttributeError: can't delete attribute
```